### PR TITLE
Allow MAJOR version higher than 0.13.0

### DIFF
--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 }


### PR DESCRIPTION
Currently breaks with latest TF version: `0.14.0`.